### PR TITLE
build: fix openzeppelin version

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "@prb/foundry-template",
       "devDependencies": {
-        "@openzeppelin/contracts": "^5.3.0",
+        "@openzeppelin/contracts": "5.3.0",
         "forge-std": "github:foundry-rs/forge-std#v1.9.7",
         "husky": "^9.1.4",
         "lint-staged": "^15.2.8",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/sablier-labs/evm-utils/issues"
   },
   "devDependencies": {
-    "@openzeppelin/contracts": "^5.3.0",
+    "@openzeppelin/contracts": "5.3.0",
     "forge-std": "github:foundry-rs/forge-std#v1.9.7",
     "husky": "^9.1.4",
     "lint-staged": "^15.2.8",


### PR DESCRIPTION
PR #28 bumped the OZ version, but it also added the caret `^` in the semver in the `package.json`.

This shouldn't have been done. Contract dependencies should always used fixed versions to guarantee that the Solidity syntax/bytecodes match.