### PR TITLE
Refactors `BaseTest` contract and adds `ci-deep` GA

### DIFF
--- a/.github/workflows/ci-deep.yml
+++ b/.github/workflows/ci-deep.yml
@@ -1,0 +1,56 @@
+name: "CI Deep"
+
+env:
+  MAINNET_RPC_URL: ${{ secrets.MAINNET_RPC_URL }}
+
+on:
+  schedule:
+    - cron: "0 3 * * 3,6" # at 3:00am UTC on Wednesday and Saturday
+  workflow_dispatch:
+    inputs:
+      integrationFuzzRuns:
+        default: "100000"
+        description: "Integration: number of fuzz runs."
+        required: false
+      invariantRuns:
+        default: "50000"
+        description: "Invariant runs: number of sequences of function calls generated and run."
+        required: false
+      invariantDepth:
+        default: "200"
+        description: "Invariant depth: number of function calls made in a given run."
+        required: false
+      forkFuzzRuns:
+        default: "20"
+        description: "Fork: number of fuzz runs."
+        required: false
+
+jobs:
+  check:
+    uses: "sablier-labs/gha-utils/.github/workflows/full-check.yml@main"
+
+  build:
+    uses: "sablier-labs/gha-utils/.github/workflows/forge-build.yml@main"
+    with:
+      foundry-profiles: "default"
+
+  test-integration:
+    needs: ["check", "build"]
+    uses: "sablier-labs/gha-utils/.github/workflows/forge-test.yml@main"
+    with:
+      foundry-fuzz-runs: ${{ fromJSON(inputs.integrationFuzzRuns || '100000') }}
+      match-path: "tests/integration/**/*.sol"
+      name: "Integration tests"
+
+  notify-on-failure:
+    if: failure()
+    needs: ["check", "build", "test-integration"]
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Send Slack notification"
+        uses: "rtCamp/action-slack-notify@v2"
+        env:
+          SLACK_CHANNEL: "#ci-notifications"
+          SLACK_MESSAGE: "CI Workflow failed for ${{ github.repository }} on branch ${{ github.ref }} at job ${{ github.job }}."
+          SLACK_USERNAME: "GitHub CI"
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "ethereum",
     "foundry",
     "sablier",
-    "sablier-v2",
     "smart-contracts",
     "solidity",
     "web3"

--- a/src/tests/BaseConstants.sol
+++ b/src/tests/BaseConstants.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.22;
+
+abstract contract BaseConstants {
+    /*//////////////////////////////////////////////////////////////////////////
+                                      GENERICS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    bytes32 public constant FEE_COLLECTOR_ROLE = keccak256("FEE_COLLECTOR_ROLE");
+    bytes32 public constant FEE_MANAGEMENT_ROLE = keccak256("FEE_MANAGEMENT_ROLE");
+    uint256 public constant MAX_FEE_USD = 100e8; // equivalent to $100
+    uint128 public constant MAX_UINT128 = type(uint128).max;
+    uint256 public constant MAX_UINT256 = type(uint256).max;
+    uint40 public constant MAX_UINT40 = type(uint40).max;
+    uint64 public constant MAX_UINT64 = type(uint64).max;
+    uint40 public constant MAX_UNIX_TIMESTAMP = 2_147_483_647; // 2^31 - 1
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                      AIRDROPS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    uint256 public constant AIRDROP_MIN_FEE_USD = 3e8; // equivalent to $3
+    uint256 public constant AIRDROP_MIN_FEE_WEI = (1e18 * AIRDROP_MIN_FEE_USD) / 3000e8; // at $3000 per ETH
+    uint256 public constant AIRDROPS_CUSTOM_FEE_USD = 0.5e8; // equivalent to $0.5
+    uint256 public constant AIRDROPS_CUSTOM_FEE_WEI = (1e18 * AIRDROPS_CUSTOM_FEE_USD) / 3000e8; // at $3000 per ETH
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                        FLOW
+    //////////////////////////////////////////////////////////////////////////*/
+
+    uint256 public constant FLOW_MIN_FEE_USD = 1e8; // equivalent to $1
+    uint256 public constant FLOW_MIN_FEE_WEI = (1e18 * FLOW_MIN_FEE_USD) / 3000e8; // at $3000 per ETH
+    uint256 public constant FLOW_CUSTOM_FEE_USD = 0.1e8; // equivalent to $0.1
+    uint256 public constant FLOW_CUSTOM_FEE_WEI = (1e18 * FLOW_CUSTOM_FEE_USD) / 3000e8; // at $3000 per ETH
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                       LOCKUP
+    //////////////////////////////////////////////////////////////////////////*/
+
+    uint256 public constant LOCKUP_MIN_FEE_USD = 1e8; // equivalent to $1
+    uint256 public constant LOCKUP_MIN_FEE_WEI = (1e18 * LOCKUP_MIN_FEE_USD) / 3000e8; // at $3000 per ETH
+    uint256 public constant LOCKUP_CUSTOM_FEE_USD = 0.1e8; // equivalent to $0.1
+    uint256 public constant LOCKUP_CUSTOM_FEE_WEI = (1e18 * LOCKUP_CUSTOM_FEE_USD) / 3000e8; // at $3000 per ETH
+}

--- a/src/tests/BaseScript.sol
+++ b/src/tests/BaseScript.sol
@@ -202,7 +202,7 @@ abstract contract BaseScript is Script {
     }
 
     /// @dev Populates the admin map. The reason the chain IDs configured for the admin map do not match the other
-    /// maps is that we only have multisigs for the chains listed below, otherwise, the default admin is used.​
+    /// maps is that we only have multisig for the chains listed below, otherwise, the default admin is used.​
     function populateAdminMap() public virtual {
         _adminMap[42_161] = 0xF34E41a6f6Ce5A45559B1D3Ee92E141a3De96376; // Arbitrum
         _adminMap[43_114] = 0x4735517616373c5137dE8bcCDc887637B8ac85Ce; // Avalanche

--- a/src/tests/BaseUtils.sol
+++ b/src/tests/BaseUtils.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.22;
+
+import { CommonBase as StdBase } from "forge-std/src/Base.sol";
+import { console2 } from "forge-std/src/console2.sol";
+import { StdStyle } from "forge-std/src/StdStyle.sol";
+import { StdUtils } from "forge-std/src/StdUtils.sol";
+
+abstract contract BaseUtils is StdBase, StdUtils {
+    /*//////////////////////////////////////////////////////////////////////////
+                                       BOUNDS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @dev Bounds a `uint128` number.
+    function boundUint128(uint128 x, uint128 min, uint128 max) internal pure returns (uint128) {
+        return uint128(_bound(x, min, max));
+    }
+
+    /// @dev Bounds a `uint40` number.
+    function boundUint40(uint40 x, uint40 min, uint40 max) internal pure returns (uint40) {
+        return uint40(_bound(x, min, max));
+    }
+
+    /// @dev Bounds a `uint64` number.
+    function boundUint64(uint64 x, uint64 min, uint64 max) internal pure returns (uint64) {
+        return uint64(_bound(x, min, max));
+    }
+
+    /// @dev Bounds a `uint8` number.
+    function boundUint8(uint8 x, uint8 min, uint8 max) internal pure returns (uint8) {
+        return uint8(_bound(x, min, max));
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                      LOGGING
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Logs a message in blue color.
+    /// @param message The message to log.
+    function logBlue(string memory message) internal pure {
+        // solhint-disable-next-line no-console
+        console2.log(StdStyle.blue(message));
+    }
+
+    /// @notice Logs a message in green color with a ✓ check mark.
+    /// @param message The message to log.
+    function logGreen(string memory message) internal pure {
+        // solhint-disable-next-line no-console
+        console2.log(StdStyle.green(string.concat(unicode"✓ ", message)));
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                        MISC
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @dev Retrieves the current block timestamp as an `uint40`.
+    function getBlockTimestamp() internal view returns (uint40) {
+        return uint40(block.timestamp);
+    }
+
+    /// @dev Stops the active prank and sets a new one.
+    function setMsgSender(address msgSender) internal {
+        vm.stopPrank();
+        vm.startPrank(msgSender);
+
+        // Deal some ETH to the new caller.
+        vm.deal(msgSender, 1 ether);
+    }
+}

--- a/tests/fork/ChainlinkOracle.t.sol
+++ b/tests/fork/ChainlinkOracle.t.sol
@@ -1,32 +1,45 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.22 <0.9.0;
 
-import { StdAssertions } from "forge-std/src/StdAssertions.sol";
-
-import { BaseScript } from "src/tests/BaseScript.sol";
 import { BaseTest } from "src/tests/BaseTest.sol";
+import { BaseScript } from "src/tests/BaseScript.sol";
 import { SablierComptroller } from "src/SablierComptroller.sol";
 
+contract BaseScriptMock is BaseScript { }
+
 // TODO: uncomment this later.
-contract ChainlinkOracle_Fork_Test is BaseScript, BaseTest, StdAssertions {
+contract ChainlinkOracle_Fork_Test is BaseTest {
+    BaseScriptMock internal baseScriptMock;
+
     /// @notice A modifier that runs the forked test for a given chain
     modifier initForkTest(string memory chainName) {
         // Fork chain on the latest block number.
         vm.createSelectFork({ urlOrAlias: chainName });
 
+        baseScriptMock = new BaseScriptMock();
+
+        // Get initial min fee USD and chainlink oracle address for `block.chainid`.
+        uint256 initialMinFeeUSD = baseScriptMock.initialMinFeeUSD();
+        address chainlinkOracle = baseScriptMock.chainlinkOracle();
+
         // Deploy the Merkle Instant factory and create a new campaign.
-        comptroller =
-            new SablierComptroller(admin, initialMinFeeUSD(), initialMinFeeUSD(), initialMinFeeUSD(), chainlinkOracle());
+        comptroller = new SablierComptroller({
+            initialAdmin: admin,
+            initialAirdropMinFeeUSD: initialMinFeeUSD,
+            initialFlowMinFeeUSD: initialMinFeeUSD,
+            initialLockupMinFeeUSD: initialMinFeeUSD,
+            initialOracle: chainlinkOracle
+        });
 
         // Assert that the Chainlink returns a non-zero price by checking the value of min fee in wei.
-        assertLt(0, comptroller.calculateAirdropsMinFeeWei(), "min fee wei");
-        assertLt(0, comptroller.calculateFlowMinFeeWei(), "min fee wei");
-        assertLt(0, comptroller.calculateLockupMinFeeWei(), "min fee wei");
+        vm.assertLt(0, comptroller.calculateAirdropsMinFeeWei(), "min fee wei");
+        vm.assertLt(0, comptroller.calculateFlowMinFeeWei(), "min fee wei");
+        vm.assertLt(0, comptroller.calculateLockupMinFeeWei(), "min fee wei");
 
         _;
     }
 
-    // function testFork_ChainlinkOracle_Mainnet() external initForkTest("mainnet") { }
+    function testFork_ChainlinkOracle_Mainnet() external initForkTest("mainnet") { }
 
     // function testFork_ChainlinkOracle_Arbitrum() external initForkTest("arbitrum") { }
 


### PR DESCRIPTION
Closes https://github.com/sablier-labs/evm-utils/issues/36

### Changelog

- Splits [`BaseTest`](https://github.com/sablier-labs/evm-utils/blob/refactor/BaseTest/src/tests/BaseTest.sol) into [`BaseUtils`](https://github.com/sablier-labs/evm-utils/blob/refactor/BaseTest/src/tests/BaseUtils.sol) and [`BaseConstants`](https://github.com/sablier-labs/evm-utils/blob/refactor/BaseTest/src/tests/BaseConstants.sol)
- Add `ci-deep` for periodic testing of `Comptroller`
- Had to declare [`BaseScriptMock`](https://github.com/sablier-labs/evm-utils/blob/refactor/BaseTest/tests/fork/ChainlinkOracle.t.sol#L8) in chainlink oracle fork test since it started to throw linearization error
- Didn't intentionally add fork test to `ci-deep`