### PR TITLE
feat: emit previous and new fees in disable and set custom fee functions

### DIFF
--- a/src/SablierComptroller.sol
+++ b/src/SablierComptroller.sol
@@ -111,11 +111,20 @@ contract SablierComptroller is ISablierComptroller, RoleAdminable {
 
     /// @inheritdoc ISablierComptroller
     function disableCustomFeeUSDFor(Protocol protocol, address user) external override onlyRole(FEE_MANAGEMENT_ROLE) {
+        // Get the current min fee USD for user.
+        uint256 previousMinFeeUSD = _getMinFeeUSDFor(protocol, user);
+
         // Effect: delete the custom fee for the provided protocol and user.
         delete _protocolFees[protocol].customFeesUSD[user];
 
         // Log the update.
-        emit ISablierComptroller.DisableCustomFeeUSD({ protocol: protocol, caller: msg.sender, user: user });
+        emit ISablierComptroller.DisableCustomFeeUSD({
+            protocol: protocol,
+            caller: msg.sender,
+            user: user,
+            previousMinFeeUSD: previousMinFeeUSD,
+            newMinFeeUSD: _protocolFees[protocol].minFeeUSD
+        });
     }
 
     /// @inheritdoc ISablierComptroller
@@ -159,6 +168,9 @@ contract SablierComptroller is ISablierComptroller, RoleAdminable {
         onlyRole(FEE_MANAGEMENT_ROLE)
         notExceedMaxFeeUSD(customFeeUSD)
     {
+        // Load the current min fee USD for user.
+        uint256 previousMinFeeUSD = _getMinFeeUSDFor(protocol, user);
+
         // Effect: enable the custom fee, if it is not already enabled.
         if (!_protocolFees[protocol].customFeesUSD[user].enabled) {
             _protocolFees[protocol].customFeesUSD[user].enabled = true;
@@ -172,7 +184,8 @@ contract SablierComptroller is ISablierComptroller, RoleAdminable {
             protocol: protocol,
             caller: msg.sender,
             user: user,
-            customFeeUSD: customFeeUSD
+            previousMinFeeUSD: previousMinFeeUSD,
+            newMinFeeUSD: customFeeUSD
         });
     }
 

--- a/src/interfaces/ISablierComptroller.sol
+++ b/src/interfaces/ISablierComptroller.sol
@@ -41,13 +41,17 @@ interface ISablierComptroller is IRoleAdminable {
     //////////////////////////////////////////////////////////////////////////*/
 
     /// @notice Emitted when the admin or the fee manager disables the custom USD fee for the provided user.
-    event DisableCustomFeeUSD(Protocol indexed protocol, address caller, address indexed user);
+    event DisableCustomFeeUSD(
+        Protocol indexed protocol, address caller, address indexed user, uint256 previousMinFeeUSD, uint256 newMinFeeUSD
+    );
 
     /// @notice Emitted when a target contract is called.
     event Execute(address indexed target, bytes data, bytes result);
 
     /// @notice Emitted when the admin or the fee manager sets the custom USD fee for the provided user.
-    event SetCustomFeeUSD(Protocol indexed protocol, address caller, address indexed user, uint256 customFeeUSD);
+    event SetCustomFeeUSD(
+        Protocol indexed protocol, address caller, address indexed user, uint256 previousMinFeeUSD, uint256 newMinFeeUSD
+    );
 
     /// @notice Emitted when the admin or the fee manager sets a new minimum USD fee.
     event SetMinFeeUSD(Protocol indexed protocol, address caller, uint256 previousMinFeeUSD, uint256 newMinFeeUSD);

--- a/tests/Base.t.sol
+++ b/tests/Base.t.sol
@@ -88,6 +88,19 @@ abstract contract Base_Test is BaseTest, Modifiers, StdAssertions {
         amountWei = (1e18 * uint256(amountUSD)) / ETH_PRICE_USD;
     }
 
+    /// @dev Returns the fee in USD for the given protocol.
+    function getFeeInUSD(ISablierComptroller.Protocol protocol) internal pure returns (uint256 feeInUSD) {
+        if (protocol == ISablierComptroller.Protocol.Airdrops) {
+            feeInUSD = AIRDROP_MIN_FEE_USD;
+        } else if (protocol == ISablierComptroller.Protocol.Flow) {
+            feeInUSD = FLOW_MIN_FEE_USD;
+        } else if (protocol == ISablierComptroller.Protocol.Lockup) {
+            feeInUSD = LOCKUP_MIN_FEE_USD;
+        } else if (protocol == ISablierComptroller.Protocol.Staking) {
+            feeInUSD = STAKING_MIN_FEE_USD;
+        }
+    }
+
     /// @dev Returns the fee in wei for the given protocol.
     function getFeeInWei(ISablierComptroller.Protocol protocol) internal pure returns (uint256 feeInWei) {
         if (protocol == ISablierComptroller.Protocol.Airdrops) {

--- a/tests/integration/concrete/comptroller/disable-custom-fee-usd-for/disableCustomFeeUSDFor.t.sol
+++ b/tests/integration/concrete/comptroller/disable-custom-fee-usd-for/disableCustomFeeUSDFor.t.sol
@@ -46,7 +46,13 @@ contract DisableCustomFeeUSDFor_Comptroller_Concrete_Test is Base_Test {
 
         // It should emit a {DisableCustomFeeUSD} event.
         vm.expectEmit({ emitter: address(comptroller) });
-        emit ISablierComptroller.DisableCustomFeeUSD(protocol, caller, users.sender);
+        emit ISablierComptroller.DisableCustomFeeUSD({
+            protocol: protocol,
+            caller: caller,
+            user: users.sender,
+            previousMinFeeUSD: 0,
+            newMinFeeUSD: getFeeInUSD(protocol)
+        });
 
         // Disable the custom fee.
         comptroller.disableCustomFeeUSDFor(protocol, users.sender);

--- a/tests/integration/concrete/comptroller/set-custom-fee-usd-for/setCustomFeeUSDFor.t.sol
+++ b/tests/integration/concrete/comptroller/set-custom-fee-usd-for/setCustomFeeUSDFor.t.sol
@@ -36,7 +36,13 @@ contract SetCustomFeeUSDFor_Comptroller_Concrete_Test is Base_Test {
         setMsgSender(users.accountant);
 
         // Set the custom fee.
-        _setCustomFeeUSDFor(protocol, users.accountant, user, customFeeUSD);
+        _setCustomFeeUSDFor({
+            protocol: protocol,
+            caller: users.accountant,
+            user: user,
+            currentFeeUSD: getFeeInUSD(protocol),
+            newCustomFeeUSD: customFeeUSD
+        });
     }
 
     function test_RevertWhen_NewFeeExceedsMaxFee(
@@ -76,7 +82,13 @@ contract SetCustomFeeUSDFor_Comptroller_Concrete_Test is Base_Test {
         assertEq(comptroller.calculateMinFeeWeiFor(protocol, user), getFeeInWei(protocol), "custom fee USD enabled");
 
         // Set the custom fee.
-        _setCustomFeeUSDFor(protocol, admin, user, customFeeUSD);
+        _setCustomFeeUSDFor({
+            protocol: protocol,
+            caller: admin,
+            user: user,
+            currentFeeUSD: getFeeInUSD(protocol),
+            newCustomFeeUSD: customFeeUSD
+        });
     }
 
     function test_WhenEnabled(
@@ -100,7 +112,13 @@ contract SetCustomFeeUSDFor_Comptroller_Concrete_Test is Base_Test {
         assertEq(comptroller.getMinFeeUSDFor(protocol, user), customFeeUSD, "custom fee USD not enabled");
 
         // Set the custom fee.
-        _setCustomFeeUSDFor(protocol, admin, user, customFeeUSD);
+        _setCustomFeeUSDFor({
+            protocol: protocol,
+            caller: admin,
+            user: user,
+            currentFeeUSD: customFeeUSD,
+            newCustomFeeUSD: customFeeUSD
+        });
     }
 
     /// @dev Shared logic to test setting the custom fee.
@@ -108,18 +126,19 @@ contract SetCustomFeeUSDFor_Comptroller_Concrete_Test is Base_Test {
         ISablierComptroller.Protocol protocol,
         address caller,
         address user,
-        uint128 customFeeUSD
+        uint256 currentFeeUSD,
+        uint128 newCustomFeeUSD
     )
         private
     {
         // It should emit a {SetCustomFeeUSD} event.
         vm.expectEmit({ emitter: address(comptroller) });
-        emit ISablierComptroller.SetCustomFeeUSD(protocol, caller, user, customFeeUSD);
+        emit ISablierComptroller.SetCustomFeeUSD(protocol, caller, user, currentFeeUSD, newCustomFeeUSD);
 
         // Set the custom fee.
-        comptroller.setCustomFeeUSDFor(protocol, user, customFeeUSD);
+        comptroller.setCustomFeeUSDFor(protocol, user, newCustomFeeUSD);
 
         // It should set the custom fee.
-        assertEq(comptroller.getMinFeeUSDFor(protocol, user), customFeeUSD, "custom fee USD");
+        assertEq(comptroller.getMinFeeUSDFor(protocol, user), newCustomFeeUSD, "custom fee USD");
     }
 }


### PR DESCRIPTION
Addresses [finding 12](https://cantina.xyz/code/ea8ed3af-8447-4295-83d4-f2cdc19b1c10/findings?finding=12).

Even though the finding is about setting custom fee, I think the same argument applies to disable fee as well. In a way, disabling custom fee is analogues to setting new fee for the user with new fee same as the default min fee. Therefore, we should emit both previous fee in USD and new fee in USD in both the functions.