### PR TITLE
test: add invariant tests for comptroller

### DIFF
--- a/.github/workflows/ci-deep.yml
+++ b/.github/workflows/ci-deep.yml
@@ -12,6 +12,14 @@ on:
         default: "100000"
         description: "Integration: number of fuzz runs."
         required: false
+      invariantRuns:
+        default: "50000"
+        description: "Invariant runs: number of sequences of function calls generated and run."
+        required: false
+      invariantDepth:
+        default: "200"
+        description: "Invariant depth: number of function calls made in a given run."
+        required: false
 
 jobs:
   check:
@@ -29,6 +37,15 @@ jobs:
       foundry-fuzz-runs: ${{ fromJSON(inputs.integrationFuzzRuns || '100000') }}
       match-path: "tests/integration/**/*.sol"
       name: "Integration tests"
+
+  test-invariant:
+    needs: ["check", "build"]
+    uses: "sablier-labs/gha-utils/.github/workflows/forge-test.yml@main"
+    with:
+      foundry-invariant-depth: ${{ fromJSON(inputs.invariantDepth || '200') }}
+      foundry-invariant-runs: ${{ fromJSON(inputs.invariantRuns || '50000') }}
+      match-path: "tests/invariant/**/*.sol"
+      name: "Invariant tests"
 
   notify-on-failure:
     if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,16 @@ jobs:
       match-path: "tests/integration/**/*.sol"
       name: "Integration tests"
 
+  test-invariant:
+    needs: ["check", "build"]
+    if: needs.build.outputs.cache-status != 'primary'
+    uses: "sablier-labs/gha-utils/.github/workflows/forge-test.yml@main"
+    with:
+      foundry-invariant-depth: 100
+      foundry-invariant-runs: 300
+      match-path: "tests/invariant/**/*.sol"
+      name: "Invariant tests"
+
   coverage:
     needs: ["check", "build"]
     if: needs.build.outputs.cache-status != 'primary'

--- a/foundry.toml
+++ b/foundry.toml
@@ -10,7 +10,6 @@
     { access = "read", path = "package.json" },
   ]
   ffi = true                        # needed for upgrade safety validations by foundry-upgrades
-  fuzz = { runs = 1000 }
   gas_reports = ["*"]
   optimizer = true
   optimizer_runs = 10_000
@@ -19,6 +18,16 @@
   solc = "0.8.29"
   src = "src"
   test = "tests"
+
+[profile.default.fuzz]
+  max_test_rejects = 1_000_000 # Number of times `vm.assume` can fail
+  runs = 1000
+
+[profile.default.invariant]
+  call_override = false  # Override unsafe external calls to perform reentrancy checks
+  depth = 100            # Number of calls executed in one run
+  fail_on_revert = true
+  runs = 200
 
 # Compile only the production code and the test mocks with via IR
 [profile.optimized]

--- a/tests/Base.t.sol
+++ b/tests/Base.t.sol
@@ -13,10 +13,11 @@ import { RoleAdminableMock } from "src/mocks/RoleAdminableMock.sol";
 import { BaseTest } from "src/tests/BaseTest.sol";
 
 import { Modifiers } from "./utils/Modifiers.sol";
+import { Utils } from "./utils/Utils.sol";
 import { Users } from "./utils/Types.sol";
 
 /// @notice Base test contract with common logic needed by all tests.
-abstract contract Base_Test is BaseTest, Modifiers, StdAssertions {
+abstract contract Base_Test is BaseTest, Modifiers, StdAssertions, Utils {
     /*//////////////////////////////////////////////////////////////////////////
                                      CONSTANTS
     //////////////////////////////////////////////////////////////////////////*/
@@ -79,44 +80,8 @@ abstract contract Base_Test is BaseTest, Modifiers, StdAssertions {
                                       HELPERS
     //////////////////////////////////////////////////////////////////////////*/
 
-    /// @dev Bound the protocol to a valid enum value.
-    function boundProtocolEnum(uint8 protocolIndex) internal pure returns (ISablierComptroller.Protocol) {
-        return ISablierComptroller.Protocol(boundUint8(protocolIndex, 0, 3));
-    }
-
-    /// @dev Convert value from USD to ETH wei.
-    function convertUSDToWei(uint128 amountUSD) internal pure returns (uint256 amountWei) {
-        amountWei = (1e18 * uint256(amountUSD)) / ETH_PRICE_USD;
-    }
-
     /// @dev Get the implementation address of the comptroller.
     function getComptrollerImplAddress() internal view returns (address payable) {
         return payable(Upgrades.getImplementationAddress(address(comptroller)));
-    }
-
-    /// @dev Returns the fee in USD for the given protocol.
-    function getFeeInUSD(ISablierComptroller.Protocol protocol) internal pure returns (uint256 feeInUSD) {
-        if (protocol == ISablierComptroller.Protocol.Airdrops) {
-            feeInUSD = AIRDROP_MIN_FEE_USD;
-        } else if (protocol == ISablierComptroller.Protocol.Flow) {
-            feeInUSD = FLOW_MIN_FEE_USD;
-        } else if (protocol == ISablierComptroller.Protocol.Lockup) {
-            feeInUSD = LOCKUP_MIN_FEE_USD;
-        } else if (protocol == ISablierComptroller.Protocol.Staking) {
-            feeInUSD = STAKING_MIN_FEE_USD;
-        }
-    }
-
-    /// @dev Returns the fee in wei for the given protocol.
-    function getFeeInWei(ISablierComptroller.Protocol protocol) internal pure returns (uint256 feeInWei) {
-        if (protocol == ISablierComptroller.Protocol.Airdrops) {
-            feeInWei = AIRDROP_MIN_FEE_WEI;
-        } else if (protocol == ISablierComptroller.Protocol.Flow) {
-            feeInWei = FLOW_MIN_FEE_WEI;
-        } else if (protocol == ISablierComptroller.Protocol.Lockup) {
-            feeInWei = LOCKUP_MIN_FEE_WEI;
-        } else if (protocol == ISablierComptroller.Protocol.Staking) {
-            feeInWei = STAKING_MIN_FEE_WEI;
-        }
     }
 }

--- a/tests/invariant/Comptroller.t.sol
+++ b/tests/invariant/Comptroller.t.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.26;
+
+import { StdInvariant } from "forge-std/src/StdInvariant.sol";
+import { ComptrollerHandler } from "./handlers/ComptrollerHandler.sol";
+
+import { Base_Test } from "../Base.t.sol";
+
+contract Comptroller_Invariant_Test is Base_Test, StdInvariant {
+    ComptrollerHandler public comptrollerHandler;
+
+    address public implAddress;
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                       SET UP
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function setUp() public override {
+        Base_Test.setUp();
+
+        // Deploy the comptroller handler.
+        comptrollerHandler = new ComptrollerHandler(address(comptroller));
+
+        // Assign the implementation address.
+        implAddress = getComptrollerImplAddress();
+
+        // Label the comptroller handler.
+        vm.label({ account: address(comptrollerHandler), newLabel: "comptrollerHandler" });
+
+        // Set the target contract.
+        targetContract(address(comptrollerHandler));
+
+        // Prevent the admin from being fuzzed as `msg.sender`.
+        excludeSender(admin);
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                      HANDLERS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @dev The invariant should not be able to change admin.
+    function invariant_Admin() external view {
+        assertEq(comptroller.admin(), admin, "Invariant violation: admin changed");
+    }
+
+    /// @dev The invariant should not be able to change the oracle.
+    function invariant_Oracle() external view {
+        assertEq(comptroller.oracle(), address(oracle), "Invariant violation: oracle changed");
+    }
+
+    /// @dev The invariant should not be able to change the implementation.
+    function invariant_Implementation() external view {
+        assertEq(getComptrollerImplAddress(), implAddress, "Invariant violation: implementation changed");
+    }
+
+    /// @dev The invariant should not be able to call any function on the comptroller.
+    function invariant_FunctionSuccess() external view {
+        assertEq(comptrollerHandler.calls("initialize"), 0, "Invariant violation: initialize called");
+        assertEq(comptrollerHandler.calls("transferAdmin"), 0, "Invariant violation: transferAdmin called");
+        assertEq(comptrollerHandler.calls("upgradeToAndCall"), 0, "Invariant violation: upgradeToAndCall called");
+    }
+}

--- a/tests/invariant/handlers/ComptrollerHandler.sol
+++ b/tests/invariant/handlers/ComptrollerHandler.sol
@@ -2,13 +2,17 @@
 pragma solidity >=0.8.26;
 
 import { UUPSUpgradeable } from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
+import { CommonBase } from "forge-std/src/Base.sol";
 import { Adminable } from "src/Adminable.sol";
+import { ISablierComptroller } from "src/interfaces/ISablierComptroller.sol";
 import { SablierComptroller } from "src/SablierComptroller.sol";
 
-contract ComptrollerHandler {
+contract ComptrollerHandler is CommonBase {
     /*//////////////////////////////////////////////////////////////////////////
                                   STATE VARIABLES
     //////////////////////////////////////////////////////////////////////////*/
+
+    address public initialAdmin;
 
     address public comptroller;
 
@@ -19,6 +23,7 @@ contract ComptrollerHandler {
     //////////////////////////////////////////////////////////////////////////*/
 
     constructor(address comptroller_) {
+        initialAdmin = ISablierComptroller(comptroller_).admin();
         comptroller = comptroller_;
     }
 
@@ -27,6 +32,8 @@ contract ComptrollerHandler {
     //////////////////////////////////////////////////////////////////////////*/
 
     function initialize(address newAdmin) external {
+        vm.assume(newAdmin != initialAdmin);
+
         (bool success,) =
             comptroller.call(abi.encodeCall(SablierComptroller.initialize, (newAdmin, 0, 0, 0, address(0))));
 
@@ -34,6 +41,8 @@ contract ComptrollerHandler {
     }
 
     function transferAdmin(address newAdmin) external {
+        vm.assume(newAdmin != initialAdmin);
+
         (bool success,) = comptroller.call(abi.encodeCall(Adminable.transferAdmin, (newAdmin)));
 
         if (success) calls["transferAdmin"]++;

--- a/tests/invariant/handlers/ComptrollerHandler.sol
+++ b/tests/invariant/handlers/ComptrollerHandler.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.26;
+
+import { UUPSUpgradeable } from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
+import { Adminable } from "src/Adminable.sol";
+import { ISablierComptroller } from "src/interfaces/ISablierComptroller.sol";
+import { SablierComptroller } from "src/SablierComptroller.sol";
+
+contract ComptrollerHandler {
+    /*//////////////////////////////////////////////////////////////////////////
+                                  STATE VARIABLES
+    //////////////////////////////////////////////////////////////////////////*/
+
+    address public comptroller;
+
+    mapping(string functionName => uint256 count) public calls;
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                    CONSTRUCTOR
+    //////////////////////////////////////////////////////////////////////////*/
+
+    constructor(address comptroller_) {
+        comptroller = comptroller_;
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                      HANDLERS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function initialize(address newAdmin) external {
+        (bool success,) =
+            comptroller.call(abi.encodeCall(ISablierComptroller.initialize, (newAdmin, 0, 0, 0, address(0))));
+
+        if (success) calls["initialize"]++;
+    }
+
+    function transferAdmin(address newAdmin) external {
+        (bool success,) = comptroller.call(abi.encodeCall(Adminable.transferAdmin, (newAdmin)));
+
+        if (success) calls["transferAdmin"]++;
+    }
+
+    function upgradeToAndCall(address newAdmin) external {
+        // Deploy a new comptroller.
+        address newImplementation = address(new SablierComptroller(newAdmin, 0, 0, 0, address(0)));
+
+        // Upgrade to the new comptroller.
+        (bool success,) = comptroller.call(abi.encodeCall(UUPSUpgradeable.upgradeToAndCall, (newImplementation, "")));
+
+        if (success) calls["upgradeToAndCall"]++;
+    }
+}

--- a/tests/invariant/handlers/ComptrollerHandler.sol
+++ b/tests/invariant/handlers/ComptrollerHandler.sol
@@ -3,7 +3,6 @@ pragma solidity >=0.8.26;
 
 import { UUPSUpgradeable } from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
 import { Adminable } from "src/Adminable.sol";
-import { ISablierComptroller } from "src/interfaces/ISablierComptroller.sol";
 import { SablierComptroller } from "src/SablierComptroller.sol";
 
 contract ComptrollerHandler {
@@ -29,7 +28,7 @@ contract ComptrollerHandler {
 
     function initialize(address newAdmin) external {
         (bool success,) =
-            comptroller.call(abi.encodeCall(ISablierComptroller.initialize, (newAdmin, 0, 0, 0, address(0))));
+            comptroller.call(abi.encodeCall(SablierComptroller.initialize, (newAdmin, 0, 0, 0, address(0))));
 
         if (success) calls["initialize"]++;
     }
@@ -42,7 +41,7 @@ contract ComptrollerHandler {
 
     function upgradeToAndCall(address newAdmin) external {
         // Deploy a new comptroller.
-        address newImplementation = address(new SablierComptroller(newAdmin, 0, 0, 0, address(0)));
+        address newImplementation = address(new SablierComptroller(newAdmin));
 
         // Upgrade to the new comptroller.
         (bool success,) = comptroller.call(abi.encodeCall(UUPSUpgradeable.upgradeToAndCall, (newImplementation, "")));

--- a/tests/utils/Utils.sol
+++ b/tests/utils/Utils.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.22 <0.9.0;
+
+import { ISablierComptroller } from "src/interfaces/ISablierComptroller.sol";
+import { BaseConstants } from "src/tests/BaseConstants.sol";
+import { BaseUtils } from "src/tests/BaseUtils.sol";
+
+contract Utils is BaseConstants, BaseUtils {
+    /// @dev Bound the protocol to a valid enum value.
+    function boundProtocolEnum(uint8 protocolIndex) internal pure returns (ISablierComptroller.Protocol) {
+        return ISablierComptroller.Protocol(boundUint8(protocolIndex, 0, 3));
+    }
+
+    /// @dev Convert value from USD to ETH wei.
+    function convertUSDToWei(uint128 amountUSD) internal pure returns (uint256 amountWei) {
+        amountWei = (1e18 * uint256(amountUSD)) / ETH_PRICE_USD;
+    }
+
+    /// @dev Returns the fee in USD for the given protocol.
+    function getFeeInUSD(ISablierComptroller.Protocol protocol) internal pure returns (uint256 feeInUSD) {
+        if (protocol == ISablierComptroller.Protocol.Airdrops) {
+            feeInUSD = AIRDROP_MIN_FEE_USD;
+        } else if (protocol == ISablierComptroller.Protocol.Flow) {
+            feeInUSD = FLOW_MIN_FEE_USD;
+        } else if (protocol == ISablierComptroller.Protocol.Lockup) {
+            feeInUSD = LOCKUP_MIN_FEE_USD;
+        } else if (protocol == ISablierComptroller.Protocol.Staking) {
+            feeInUSD = STAKING_MIN_FEE_USD;
+        }
+    }
+
+    /// @dev Returns the fee in wei for the given protocol.
+    function getFeeInWei(ISablierComptroller.Protocol protocol) internal pure returns (uint256 feeInWei) {
+        if (protocol == ISablierComptroller.Protocol.Airdrops) {
+            feeInWei = AIRDROP_MIN_FEE_WEI;
+        } else if (protocol == ISablierComptroller.Protocol.Flow) {
+            feeInWei = FLOW_MIN_FEE_WEI;
+        } else if (protocol == ISablierComptroller.Protocol.Lockup) {
+            feeInWei = LOCKUP_MIN_FEE_WEI;
+        } else if (protocol == ISablierComptroller.Protocol.Staking) {
+            feeInWei = STAKING_MIN_FEE_WEI;
+        }
+    }
+}


### PR DESCRIPTION
Depends on https://github.com/sablier-labs/evm-utils/pull/54

Since (1) proxy exposes `fallback` function (2) Comptroller has `initialize` function, I added invariant tests to verify that nobody other than admin can change any of the comptroller's states. 

To test it, if you remove `initializer` modifier from `initialize` function, you will see the invariant tests fail. Therefore, the tests are useful to detect cases where we incorrectly implement the upgradeability of the comptroller which could allow anyone to change the admin or other states.